### PR TITLE
Add linebreak to toEqualImmutable message for better comparison

### DIFF
--- a/packages/custom-immutable-matchers/src/matchers.js
+++ b/packages/custom-immutable-matchers/src/matchers.js
@@ -88,6 +88,10 @@ export const toBeImmutableSeq = comparator((actual) => {
 
 export const toEqualImmutable = comparator((actual, expected) => {
   const pass = Immutable.is(actual, expected)
-  const message = `Expected ${toString(actual)}${pass ? ' not' : ''} to equal ${toString(expected)}`
+  const message = `Expected
+${toString(actual)}
+${pass ? ' not' : ''} to equal
+${toString(expected)}
+`
   return {pass, message}
 })


### PR DESCRIPTION
This pull request update the error message of toEqualImmutable, It is helpful for comparing large Immutable Objects:

```js
//previous
Expected Map { "id": 2, "name": "Jack" } to equal Map { "id": 1, "name": "James" }

//pull-request
Expected
Map { "id": 2, "name": "Jack" }
to equal
Map { "id": 1, "name": "James" }
```