### PR TITLE
Set jasmine-core as peer dependency instead of jasmine

### DIFF
--- a/packages/jasmine-immutable-matchers/package.json
+++ b/packages/jasmine-immutable-matchers/package.json
@@ -28,7 +28,7 @@
     "prepublish": "run-s clean build"
   },
   "peerDependencies": {
-    "jasmine": "*",
+    "jasmine-core": "*",
     "immutable": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes annoying warning:
```bash
npm WARN jasmine-immutable-matchers@1.4.0 requires a peer of jasmine@* but none was installed.
```

**Motivation:**

No one imports `jasmine` as this package is command line tool. I presume that 99% of the projects has `jasmine-core` in there `package.json` instead of `jasmine`. 
