### PR TITLE
update jest matcher format

### DIFF
--- a/packages/custom-immutable-matchers/package.json
+++ b/packages/custom-immutable-matchers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "custom-immutable-matchers",
   "description": "Add a set of custom matchers for Immutable related checks.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/custom-immutable-matchers.js",
   "typings": "index.d.ts",
   "license": "MIT",

--- a/packages/custom-immutable-matchers/src/matchers.js
+++ b/packages/custom-immutable-matchers/src/matchers.js
@@ -1,8 +1,6 @@
 import * as Immutable from 'immutable'
 
-const comparator = (func) => () => ({
-  compare: func
-})
+const comparator = (func) => func
 
 const toString = function (obj) {
   return obj && typeof obj.toString === 'function' ? obj.toString() : obj

--- a/packages/jest-immutable-matchers/package.json
+++ b/packages/jest-immutable-matchers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-immutable-matchers",
   "description": "Add a set of custom matchers for Immutable related checks.",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "main": "dist/jest-immutable-matchers.js",
   "typings": "index.d.ts",
   "license": "MIT",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/jest": "^22.0.1",
     "babel-jest": "^22.1.0",
-    "custom-immutable-matchers": "^2.0.0",
+    "custom-immutable-matchers": "^3.0.0",
     "jest": "^22.1.2",
     "npm-run-all": "^4.1.2",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
jest changed the expected return value of custom matches. Instead of an anonymous function that returns object `{ compare: fn }` jest expects to return the compare `fn`. I marked those changes as breaking to avoid break for users with old jest versions. I couldn't find quickly in jest changelog which version changes the format. If it's necessary, I'll find the exact version.

Related issue #43 